### PR TITLE
Feature/reflect renaming

### DIFF
--- a/include/roki-fd/rkfd_util.h
+++ b/include/roki-fd/rkfd_util.h
@@ -34,8 +34,8 @@ __EXPORT zVec6D *rkFDChainPointRelativeAcc6D(rkCDPairDat *pd, zVec3D *p, zVec6D 
 /******************************************************************************/
 /* update and set ABIPrp */
 __EXPORT void rkFDUpdateAccBias(rkFDChainArray *chains);
-__EXPORT void rkFDChainUpdateAccAddExForceTwo(rkCDPairDat *pd, rkWrench *w[]); /* TODO: Rename */
-__EXPORT void rkFDChainABIPopPrpExForceTwo(rkCDPairDat *pd); /* TODO: Rename */
+__EXPORT void rkFDChainUpdateCachedABIPair(rkCDPairDat *pd, rkWrench *w[]);
+__EXPORT void rkFDChainRestoreABIAccBiasPair(rkCDPairDat *pd);
 
 /******************************************************************************/
 __EXPORT void rkFDChainExtWrenchDestroy(rkChain *chain);

--- a/include/roki-fd/rkfd_util.h
+++ b/include/roki-fd/rkfd_util.h
@@ -34,8 +34,8 @@ __EXPORT zVec6D *rkFDChainPointRelativeAcc6D(rkCDPairDat *pd, zVec3D *p, zVec6D 
 /******************************************************************************/
 /* update and set ABIPrp */
 __EXPORT void rkFDUpdateAccBias(rkFDChainArray *chains);
-__EXPORT void rkFDChainUpdateAccAddExForceTwo(rkCDPairDat *pd, rkWrench *w[]);
-__EXPORT void rkFDChainABIPopPrpExForceTwo(rkCDPairDat *pd);
+__EXPORT void rkFDChainUpdateAccAddExForceTwo(rkCDPairDat *pd, rkWrench *w[]); /* TODO: Rename */
+__EXPORT void rkFDChainABIPopPrpExForceTwo(rkCDPairDat *pd); /* TODO: Rename */
 
 /******************************************************************************/
 __EXPORT void rkFDChainExtWrenchDestroy(rkChain *chain);

--- a/src/rkfd_mlcp.c
+++ b/src/rkfd_mlcp.c
@@ -113,12 +113,12 @@ static void _rkFDSolverRelationAccForceOne(rkFDSolver *s, rkCDPairDat *cpd, rkCD
     if( cpd->cell[j] != cdv->data.cell )
       zVec3DRevDRC( rkWrenchForce(_prp(s)->w[j]) );
   }
-  rkFDChainUpdateAccAddExForceTwo( cpd, _prp(s)->w );
+  rkFDChainUpdateCachedABIPair( cpd, _prp(s)->w );
   _rkFDSolverRelativeAcc( s, cpd, _prp(s)->b, _prp(s)->t );
   zMatPutCol( _prp(s)->a, offset, _prp(s)->t );
 
   /* restore ABIPrp */
-  rkFDChainABIPopPrpExForceTwo( cpd );
+  rkFDChainRestoreABIAccBiasPair( cpd );
 }
 
 static void _rkFDSolverRelationAccForce(rkFDSolver *s)

--- a/src/rkfd_sim.c
+++ b/src/rkfd_sim.c
@@ -176,7 +176,7 @@ rkFDCellDat *_rkFDCellDatJointFrictionPivotInit(rkFDCellDat *ld)
 
 rkFDCellDat *_rkFDCellDatInit(rkFDCellDat *ld)
 {
-  rkChainABIAlloc( rkFDCellDatChain(ld) );
+  rkChainAllocABI( rkFDCellDatChain(ld) );
   ld->_dis.size = ld->_vel.size = ld->_acc.size = rkChainJointSize( rkFDCellDatChain(ld) );
   ld->_dis.buf = NULL;
   ld->_vel.buf = NULL;
@@ -506,11 +506,11 @@ void _rkFDUpdateAcc(rkFD *fd, bool doUpRef)
   void (*update)(rkChain*);
 
   if( !doUpRef ){
-    update_abi = &rkChainABIUpdateAddExForce;
-    update     = &rkChainABIUpdate;
+    update_abi = &rkChainUpdateCachedABI;
+    update     = &rkChainUpdateABI;
   } else {
-    update_abi = &rkChainABIUpdateAddExForceGetWrench;
-    update     = &rkChainABIUpdateGetWrench;
+    update_abi = &rkChainUpdateCachedABIWrench;
+    update     = &rkChainUpdateABIWrench;
   }
 
   zListForEach( &fd->list, lc ){

--- a/src/rkfd_util.c
+++ b/src/rkfd_util.c
@@ -153,8 +153,8 @@ void rkFDUpdateAccBias(rkFDChainArray *chains)
   rkFDArrayForEach( chains, c ){
     if( (*c)->has_rigid_col ){
       (*c)->done_abi_init = true;
-      rkChainABIUpdate( &(*c)->chain );
-      rkChainABIPushPrpAccBias( &(*c)->chain );
+      rkChainUpdateABI( &(*c)->chain );
+      rkChainSaveABIAccBias( &(*c)->chain );
       rkFDChainExtWrenchDestroy( &(*c)->chain );
     }
   }
@@ -163,20 +163,20 @@ void rkFDUpdateAccBias(rkFDChainArray *chains)
 void rkFDChainUpdateAccAddExForceTwo(rkCDPairDat *pd, rkWrench *w[])
 {
   if( pd->cell[0]->data.chain == pd->cell[1]->data.chain ) /* self collision */
-    rkChainABIUpdateAddExForceTwo( pd->cell[0]->data.chain, pd->cell[0]->data.link, w[0], pd->cell[1]->data.link, w[1] );
+    rkChainUpdateCachedABIPair( pd->cell[0]->data.chain, pd->cell[0]->data.link, w[0], pd->cell[1]->data.link, w[1] );
   else {
-    rkChainABIUpdateAddExForceTwo( pd->cell[0]->data.chain, pd->cell[0]->data.link, w[0], NULL, NULL );
-    rkChainABIUpdateAddExForceTwo( pd->cell[1]->data.chain, pd->cell[1]->data.link, w[1], NULL, NULL );
+    rkChainUpdateCachedABIPair( pd->cell[0]->data.chain, pd->cell[0]->data.link, w[0], NULL, NULL );
+    rkChainUpdateCachedABIPair( pd->cell[1]->data.chain, pd->cell[1]->data.link, w[1], NULL, NULL );
   }
 }
 
 void rkFDChainABIPopPrpExForceTwo(rkCDPairDat *pd)
 {
   if( pd->cell[0]->data.chain == pd->cell[1]->data.chain )
-    rkChainABIPopPrpAccBiasAddExForceTwo( pd->cell[0]->data.chain, pd->cell[0]->data.link, pd->cell[1]->data.link );
+    rkChainRestoreABIAccBiasPair( pd->cell[0]->data.chain, pd->cell[0]->data.link, pd->cell[1]->data.link );
   else {
-    rkChainABIPopPrpAccBiasAddExForceTwo( pd->cell[0]->data.chain, pd->cell[0]->data.link, NULL );
-    rkChainABIPopPrpAccBiasAddExForceTwo( pd->cell[1]->data.chain, pd->cell[1]->data.link, NULL );
+    rkChainRestoreABIAccBiasPair( pd->cell[0]->data.chain, pd->cell[0]->data.link, NULL );
+    rkChainRestoreABIAccBiasPair( pd->cell[1]->data.chain, pd->cell[1]->data.link, NULL );
   }
 }
 

--- a/src/rkfd_util.c
+++ b/src/rkfd_util.c
@@ -160,7 +160,7 @@ void rkFDUpdateAccBias(rkFDChainArray *chains)
   }
 }
 
-void rkFDChainUpdateAccAddExForceTwo(rkCDPairDat *pd, rkWrench *w[])
+void rkFDChainUpdateCachedABIPair(rkCDPairDat *pd, rkWrench *w[])
 {
   if( pd->cell[0]->data.chain == pd->cell[1]->data.chain ) /* self collision */
     rkChainUpdateCachedABIPair( pd->cell[0]->data.chain, pd->cell[0]->data.link, w[0], pd->cell[1]->data.link, w[1] );
@@ -170,7 +170,7 @@ void rkFDChainUpdateAccAddExForceTwo(rkCDPairDat *pd, rkWrench *w[])
   }
 }
 
-void rkFDChainABIPopPrpExForceTwo(rkCDPairDat *pd)
+void rkFDChainRestoreABIAccBiasPair(rkCDPairDat *pd)
 {
   if( pd->cell[0]->data.chain == pd->cell[1]->data.chain )
     rkChainRestoreABIAccBiasPair( pd->cell[0]->data.chain, pd->cell[0]->data.link, pd->cell[1]->data.link );

--- a/src/rkfd_vert.c
+++ b/src/rkfd_vert.c
@@ -171,12 +171,12 @@ static void _rkFDSolverRelationAccForce(rkFDSolver *s)
           if( (*pd)->cell[j] != cdv->data.cell )
             zVec3DRevDRC( rkWrenchForce(_prp(s)->w[j]) );
         }
-        rkFDChainUpdateAccAddExForceTwo( *pd, _prp(s)->w );
+        rkFDChainUpdateCachedABIPair( *pd, _prp(s)->w );
         _rkFDSolverRelativeAcc( s, *pd, _prp(s)->b, _prp(s)->t );
         zMatPutCol( _prp(s)->a, offset+i, _prp(s)->t );
 
         /* restore ABIPrp */
-        rkFDChainABIPopPrpExForceTwo( *pd );
+        rkFDChainRestoreABIAccBiasPair( *pd );
       }
       offset += 3;
     }

--- a/src/rkfd_volume.c
+++ b/src/rkfd_volume.c
@@ -197,11 +197,11 @@ static void _rkFDSolverRelationAccForce(rkFDSolver *s)
         if( j != 0 )
           zVec6DRevDRC( rkWrenchW(_prp(s)->w[j]) );
       }
-      rkFDChainUpdateAccAddExForceTwo( *pd, _prp(s)->w );
+      rkFDChainUpdateCachedABIPair( *pd, _prp(s)->w );
       _rkFDSolverRelativeAcc( s, *pd, _prp(s)->b, _prp(s)->t );
       zMatPutCol( _prp(s)->a, offset+i, _prp(s)->t );
       /* restore ABIPrp */
-      rkFDChainABIPopPrpExForceTwo( *pd );
+      rkFDChainRestoreABIAccBiasPair( *pd );
     }
     offset += 6;
   }


### PR DESCRIPTION
#24 
こちら対応しました。

また、合わせてABIを使っている以下の関数名を変更しました
```
rkFDChainUpdateAccAddExForceTwo -> rkFDChainUpdateCachedABIPair
rkFDChainABIPopPrpExForceTwo -> rkFDChainRestoreABIAccBiasPair
```
その他の関数について、こちら(https://github.com/mi-lib/roki/issues/14) で指摘されているのと同様の問題があるものがありますが、別issueを立てておいおい修正するようにしようと思います。

PRを出すブランチについてですが、小さな修正などは直接mainに出し、機能追加などいくつかのPRをマージした後動作確認が必要そうなものはdevelopに出すようにすることにしました。