### PR TITLE
C++対応

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,5 @@
+2023. 3.30. Abolished register keywords. [rkfd_util, rkfd_sim, rkfd_vert, rkfd_volume, rkfd_mlcp]
+2023. 3.30. Modified config.lib and config.tools for C++ compilation. [src, tools]
 2022.12.29. Renamed rkFDChainUpdateAccAddExForceTwo and rkFDChainABIPopPrpExForceTwo to rkFDChainUpdateCachedABIPair and rkFDChainRestoreABIAccBiasPair. [rkfd_util]
 2022.12.29. Reflected renaming of rkChainABIAlloc, rkChainABIUpdate, rkChainABIUpdateGetWrench, rkChainABIUpdateAddExForce, rkChainABIUpdateAddExForceGetWrench, rkChainABIPushPrpAccBias, rkChainABIUpdateAddExForceTwo, rkChainABIPopPrpAccBiasAddExForceTwo. [rkfd_util, rkfd_sim, rkfd_mlcp, rkfd_vert, rkfd_volume]
 2021. 6. 1. Applied new zeda-makefile-gen to compilation of shared objects. [src]

--- a/config.org
+++ b/config.org
@@ -2,4 +2,4 @@ PREFIX=$(HOME)/usr
 PROJNAME=roki-fd
 VERSION=1.4.5
 
-DEPENDENCY="zeda=1.6.21;zm=1.4.4;zeo=1.10.2;roki=2.0.1"
+DEPENDENCY="zeda=1.6.45;zm=1.6.3;zeo=1.12.3;roki=2.0.13"

--- a/src/config.lib
+++ b/src/config.lib
@@ -5,4 +5,3 @@ OBJ=rkfd_property.o\
 	rkfd_sim.o\
 	rkfd_penalty.o\
 	rkfd_vert.o rkfd_volume.o rkfd_mlcp.o
-DLIB=libroki-fd.so

--- a/src/rkfd_mlcp.c
+++ b/src/rkfd_mlcp.c
@@ -59,7 +59,7 @@ static void _rkFDSolverBiasAcc(rkFDSolver *s, zVec acc)
 {
   rkCDPairDat **pd;
   rkCDVert *cdv;
-  register int i;
+  int i;
   int offset = 0;
   zVec3D av;
 
@@ -79,7 +79,7 @@ static void _rkFDSolverRelativeAcc(rkFDSolver *s, rkCDPairDat *cpd, zVec b, zVec
   rkCDVert *cdv;
   int offset = 0;
   zVec3D av;
-  register int i;
+  int i;
 
   rkFDCDForEachRigidPair( s->cd, pd ){
     if( (*pd)->cell[0]->data.chain != cpd->cell[0]->data.chain &&
@@ -103,7 +103,7 @@ static void _rkFDSolverRelativeAcc(rkFDSolver *s, rkCDPairDat *cpd, zVec b, zVec
 
 static void _rkFDSolverRelationAccForceOne(rkFDSolver *s, rkCDPairDat *cpd, rkCDVert *cdv, zVec3D *axis, int offset)
 {
-  register int j;
+  int j;
 
   for( j=0; j<2; j++ ){
     rkWrenchInit( _prp(s)->w[j] );
@@ -125,7 +125,7 @@ static void _rkFDSolverRelationAccForce(rkFDSolver *s)
 {
   rkCDPairDat **pd;
   rkCDVert *cdv;
-  register int i;
+  int i;
   int offset = 0;
 
   /* b */
@@ -148,7 +148,7 @@ static void _rkFDSolverBiasVel(rkFDSolver *s)
   rkCDPairDat **pd;
   rkCDVert *cdv;
   int offset = 0;
-  register int i;
+  int i;
 
   zVecMulDRC( _prp(s)->b, rkFDPrpDT(s->fdprp) );
   rkFDCDForEachRigidPair( s->cd, pd ){
@@ -165,7 +165,7 @@ static void _rkFDSolverRelaxationCompensation(rkFDSolver *s)
 {
   rkCDPairDat **pd;
   rkCDVert *cdv;
-  register int i;
+  int i;
   int offset = 0;
   zVec3D d;
   double k;
@@ -194,7 +194,7 @@ static void _rkFDSolverMLCP(rkFDSolver *s)
   int offset = 0;
   int cnt = 0;
   double ff[2], fs, fnorm;
-  register int i;
+  int i;
 
   /* MLCP */
   zVecZero( _prp(s)->f );
@@ -254,7 +254,7 @@ static void _rkFDSolverSetForce(rkFDSolver *s, bool doUpRef)
   rkCDPairDat **pd;
   rkCDVert *cdv;
   int offset = 0;
-  register int i;
+  int i;
   double fn ,fs, mu;
 
   rkFDCDForEachRigidPair( s->cd, pd ){

--- a/src/rkfd_sim.c
+++ b/src/rkfd_sim.c
@@ -195,11 +195,7 @@ rkFDCell *_rkFDCellPush(rkFD *fd, rkFDCell *lc)
     return NULL;
   }
   /* cd reg */
-#if 0
-  rkCDChainReg( rkFDCDBase(&fd->cd), rkFDCellChain(lc), true );
-#else
   rkCDChainReg( rkFDCDBase(&fd->cd), rkFDCellChain(lc), RK_CD_CELL_MOVE );
-#endif
   /* set contact info */
   zListForEach( &rkFDCDBase(&fd->cd)->plist, cdp ){
     if( cdp->data.ci == NULL ){

--- a/src/rkfd_sim.c
+++ b/src/rkfd_sim.c
@@ -156,7 +156,7 @@ bool _rkFDAllocJointStatePop(rkFD *fd, rkFDCell *rlc)
 
 rkFDCellDat *_rkFDCellDatJointFrictionPivotInit(rkFDCellDat *ld)
 {
-  register int i, j;
+  int i, j;
   rkJoint *joint;
   double val[6];
   rkJointFrictionPivot jfp[6];
@@ -195,7 +195,11 @@ rkFDCell *_rkFDCellPush(rkFD *fd, rkFDCell *lc)
     return NULL;
   }
   /* cd reg */
+#if 0
   rkCDChainReg( rkFDCDBase(&fd->cd), rkFDCellChain(lc), true );
+#else
+  rkCDChainReg( rkFDCDBase(&fd->cd), rkFDCellChain(lc), RK_CD_CELL_MOVE );
+#endif
   /* set contact info */
   zListForEach( &rkFDCDBase(&fd->cd)->plist, cdp ){
     if( cdp->data.ci == NULL ){
@@ -474,7 +478,7 @@ void _rkFDUpdateCD(rkFD *fd, bool doUpRef)
 bool _rkFDUpdateInitSolver(rkFD *fd)
 {
   rkFDCell *lc;
-  register int i;
+  int i;
 
   if( zListSize(&fd->list) != 0 ){
     zArrayAlloc( rkFDSolverChains(&fd->solver), rkFDChain*, zListSize(&fd->list) );
@@ -533,9 +537,9 @@ void _rkFDUpdateAll(rkFD *fd, double t, bool doUpRef)
 zVec _rkFDUpdate(double t, zVec dis, zVec vel, void *fd, zVec acc)
 {
   zVecZero( acc );
-  _rkFDConnectJointState( fd, dis, vel, acc );
-  _rkFDUpdateAll( fd, t, false );
-  _rkFDUpdateAcc( fd, false );
+  _rkFDConnectJointState( (rkFD *)fd, dis, vel, acc );
+  _rkFDUpdateAll( (rkFD *)fd, t, false );
+  _rkFDUpdateAcc( (rkFD *)fd, false );
   return acc;
 }
 

--- a/src/rkfd_util.c
+++ b/src/rkfd_util.c
@@ -42,7 +42,7 @@ void rkFDLinkAddSlideVel(rkCDCell *cell, zVec3D *p, zVec3D *n, zVec3D *v)
 zVec3D *rkFDChainPointRelativeVel(rkCDPairDat *pd, zVec3D *p, zVec3D *n, rkCDCell *cell, zVec3D *v)
 {
   zVec3D vv[2];
-  register int i;
+  int i;
 
   for( i=0; i<2; i++ ){
     if( pd->cell[i]->data.type == RK_CD_CELL_STAT )
@@ -73,7 +73,7 @@ zVec6D *rkFDLinkPointWldVel6D(rkLink *link, zVec3D *p, zVec6D *v)
 zVec6D *rkFDChainPointRelativeVel6D(rkCDPairDat *pd, zVec3D *p, zVec3D *n, zVec6D *v)
 {
   zVec6D vv[2];
-  register int i;
+  int i;
 
   for( i=0; i<2; i++ ){
     if( pd->cell[i]->data.type == RK_CD_CELL_STAT )
@@ -103,7 +103,7 @@ zVec3D *rkFDLinkPointWldAcc(rkLink *link, zVec3D *p, zVec3D *a)
 zVec3D *rkFDChainPointRelativeAcc(rkCDPairDat *pd, zVec3D *p, rkCDCell *cell, zVec3D *a)
 {
   zVec3D av[2];
-  register int i;
+  int i;
 
   for( i=0; i<2; i++ )
     if( pd->cell[i]->data.type == RK_CD_CELL_STAT )
@@ -132,7 +132,7 @@ zVec6D *rkFDLinkPointWldAcc6D(rkLink *link, zVec3D *p, zVec6D *a)
 zVec6D *rkFDChainPointRelativeAcc6D(rkCDPairDat *pd, zVec3D *p, zVec6D *a)
 {
   zVec6D av[2];
-  register int i;
+  int i;
 
   for( i=0; i<2; i++ )
     if( pd->cell[i]->data.type == RK_CD_CELL_STAT )
@@ -184,7 +184,7 @@ void rkFDChainRestoreABIAccBiasPair(rkCDPairDat *pd)
 /* destroy temporary wrench list */
 void rkFDChainExtWrenchDestroy(rkChain *chain)
 {
-  register int i;
+  int i;
 
   for( i=0; i<rkChainLinkNum(chain); i++ )
     rkWrenchListDestroy( rkLinkExtWrenchBuf(rkChainLink(chain,i)) );
@@ -197,7 +197,7 @@ double rkFDKineticFrictionWeight(double w, double fs)
 
 /* sin cos table */
 bool rkFDCrateSinCosTable(zVec table[2], int num, double offset){
-	register int i;
+	int i;
 	double th, dth;
 
 	table[0] = zVecAlloc( num );
@@ -216,7 +216,7 @@ bool rkFDCrateSinCosTable(zVec table[2], int num, double offset){
 /* contact force */
 void rkFDUpdateRefSlide(rkCDPairDat *pd, rkCDVert *cdv, double dt)
 {
-  register int i;
+  int i;
   zVec3D tmpv, sv;
 
   /* for slide mode */
@@ -267,7 +267,7 @@ void rkFDContactForceModifyFriction(rkFDPrp *prp, rkCDPairDat *pd, rkCDVert *cdv
 void rkFDContactForcePushWrench(rkCDPairDat *pd, rkCDVert *cdv)
 {
   rkWrench *w;
-  register int i;
+  int i;
 
   for( i=0; i<2; i++){
     w = zAlloc( rkWrench, 1 );
@@ -290,7 +290,7 @@ void rkFDUpdateJointPrevDrivingTrq(rkFDChainArray *chains)
   rkFDChain **fdc;
   rkChain *chain;
   rkJoint *joint;
-  register int i, j;
+  int i, j;
   double val[6], tf[6];
   rkJointFrictionPivot jfp[6];
 
@@ -317,7 +317,7 @@ void rkFDUpdateJointPrevDrivingTrq(rkFDChainArray *chains)
 void rkFDJointFrictionAll(rkJoint *joint, double weight)
 {
   double kf[6], v[6];
-  register int i;
+  int i;
 
   rkJointGetKFriction( joint, kf );
   rkJointGetVel( joint, v );
@@ -368,7 +368,7 @@ void rkFDJointFriction(rkFDChainArray *chains, double dt, double weight, bool do
   rkChain *chain;
   rkJoint *joint;
   rkMotor *motor;
-  register int i;
+  int i;
 
   rkFDArrayForEach( chains, fdc ){
     chain = rkFDChainBase( *fdc );

--- a/src/rkfd_vert.c
+++ b/src/rkfd_vert.c
@@ -73,7 +73,7 @@ static void _rkFDSolverFrictionConstraint(rkFDSolver *s)
 {
   rkCDPairDat **pd;
   rkCDVert *cdv;
-  register int i;
+  int i;
   int cnt = 0;
   int cnum;
   int offset, ioffset;
@@ -107,7 +107,7 @@ static void _rkFDSolverBiasAcc(rkFDSolver *s, zVec acc)
 {
   rkCDPairDat **pd;
   rkCDVert *cdv;
-  register int i;
+  int i;
   int offset = 0;
   zVec3D av;
 
@@ -125,7 +125,7 @@ static void _rkFDSolverRelativeAcc(rkFDSolver *s, rkCDPairDat *cpd, zVec b, zVec
 {
   rkCDPairDat **pd;
   rkCDVert *cdv;
-  register int i;
+  int i;
   int offset = 0;
   zVec3D av;
 
@@ -153,7 +153,7 @@ static void _rkFDSolverRelationAccForce(rkFDSolver *s)
 {
   rkCDPairDat **pd;
   rkCDVert *cdv;
-  register int i, j;
+  int i, j;
   int offset = 0;
 
   /* b */
@@ -232,7 +232,7 @@ static void _rkFDSolverCompensateDepth(rkFDSolver *s)
 
 static zVec _rkFDSolverQPASMInit(rkFDSolver *s, zVec ans)
 {
-  register int i;
+  int i;
 
   zVecZero( ans );
   for( i=0; i<_prp(s)->colnum; i++ )
@@ -288,7 +288,7 @@ static void _rkFDSolverSetForce(rkFDSolver *s, bool doUpRef)
 {
   rkCDPairDat **pd;
   rkCDVert *cdv;
-  register int i;
+  int i;
   int cnt = 0, offset, ioffset, cnum;
   bool flag;
 

--- a/src/rkfd_volume.c
+++ b/src/rkfd_volume.c
@@ -173,7 +173,7 @@ static void _rkFDSolverRelativeAcc(rkFDSolver *s, rkCDPairDat *cpd, zVec b, zVec
 static void _rkFDSolverRelationAccForce(rkFDSolver *s)
 {
   rkCDPairDat **pd;
-  register int i, j;
+  int i, j;
   int offset = 0;
   zVec3D pos[2];
 
@@ -275,7 +275,7 @@ static double _rkFDSolverConstrainArea(zVec3D p[])
 
 static void _rkFDSolverConstraintAddQ(zVec3D p[], zVec3D pm[], double s, zMat6D *q)
 {
-  register int i;
+  int i;
   zVec3D pc;
   zMat3D mm[3], tmpm;
 
@@ -292,7 +292,7 @@ static void _rkFDSolverConstraintAddQ(zVec3D p[], zVec3D pm[], double s, zMat6D 
 
 static void _rkFDSolverConstraintDepth(zVec3D pm[], double h[], rkContactInfo *ci, double s, zVec3D norm, zVec6D *c)
 {
-  register int i;
+  int i;
   double hm[3], hc;
   zVec3D tmpv;
 
@@ -308,7 +308,7 @@ static void _rkFDSolverConstraintDepth(zVec3D pm[], double h[], rkContactInfo *c
 
 static void _rkFDSolverConstraintSignDepth(double h[], int *st, int stp[])
 {
-  register int i;
+  int i;
 
   *st = 0;
   stp[0] = stp[1] = stp[2] = 0;
@@ -393,7 +393,7 @@ static int __rk_fd_plane_cmp(void *p1, void *p2, void *priv)
 
 static void _rkFDSolverConstraint(rkCDPairDat *cpd, zMat6D *q, zVec6D *c)
 {
-  register int i, j;
+  int i, j;
   zTri3D *face;
   double h[3], s;
   zVec3D pf[3], p[3], pm[3], pp[2];
@@ -495,7 +495,7 @@ static void _rkFDSolverQPCreate(rkFDSolver *s)
   zMat6D qv;
   zVec6D cv, tmpv;
   rkCDPairDat **pd;
-  register int i, j;
+  int i, j;
   int offset = 0;
 
   zMatZero( _prp(s)->q );
@@ -649,7 +649,7 @@ static void _rkFDSolverModifyWrenchStaticSetSize(rkFDSolver *s, rkCDPairDat *cpd
 static void _rkFDSolverModifyWrenchStaticConstraint(rkFDSolver *s, rkCDPairDat *cpd, zVec6D *w)
 {
   rkCDPlane *cdpl;
-  register int i;
+  int i;
   int offset = 0;
 
   zListForEach( &cpd->cplane, cdpl ){
@@ -775,7 +775,7 @@ static void _rkFDSolverPlaneVertSlideDir(rkFDSolver *s, rkCDPairDat *cpd, rkCDPl
 static void _rkFDSolverModifyWrenchKineticEvalFunc(rkFDSolver *s, rkCDPairDat *cpd, zVec6D *w)
 {
   rkCDPlane *cdpl;
-  register int i;
+  int i;
   int offset = 0;
   double wn[3];
 
@@ -792,7 +792,7 @@ static void _rkFDSolverModifyWrenchKineticEvalFunc(rkFDSolver *s, rkCDPairDat *c
 static void _rkFDSolverModifyWrenchKineticEvalFuncSafety(rkFDSolver *s, rkCDPairDat *cpd, zVec6D *w)
 {
   rkCDPlane *cdpl;
-  register int i;
+  int i;
   int offset = 0;
   double wn[2];
 
@@ -854,7 +854,7 @@ static void _rkFDSolverModifyWrenchSetKinetic(rkCDPairDat *cpd, bool doUpRef)
 
 static void _rkFDSolverModifyWrenchSetForce(rkCDPairDat *cpd, zVec6D *w)
 {
-  register int i;
+  int i;
 
   zVec6DZero( &cpd->f );
   for( i=0; i<3; i++ ){
@@ -868,7 +868,7 @@ static void _rkFDSolverModifyWrench(rkFDSolver *s, bool doUpRef)
   rkCDPairDat **pd;
   zVec6D w;
   double fn, fs, tl;
-  register int i;
+  int i;
 
   rkFDCDForEachRigidPair( s->cd, pd ){
     if( zListIsEmpty(&(*pd)->cplane) ) continue;
@@ -917,7 +917,7 @@ static void _rkFDSolverPushWrench(rkFDSolver *s)
 {
   rkCDPairDat **pd;
   rkWrench *w;
-  register int i;
+  int i;
 
   rkFDCDForEachRigidPair( s->cd, pd ){
     for( i=0; i<2; i++ ){

--- a/tools/config.tools
+++ b/tools/config.tools
@@ -2,3 +2,4 @@ INCLUDE+=`roki-config -I`
 LIB+=`roki-config -L`
 DEF+=`roki-config -D`
 LINK+=`roki-config -l`
+LINKCPP+=`roki-config -lcpp`


### PR DESCRIPTION
@n-wakisaka 
ライブラリをC++で使いたいという要望が出ているので、ぼちぼち対応進めています。
 - registerキーワードの廃止
 - キャストの厳格化
 - libroki-fd_cpp.soの作成とroki-fd-config -lcpp機能の追加
あたりが主な変更点です。チェックしてもらえますか？

rkfd_sim.cでも不整合が生じているので、別issueで質問させてもらいます。そちらも対応してもらえると助かります。