### PR TITLE
Fix/alloc workspace #38

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,4 @@
+2023. 6.19. Debugged _rkFDSolverPrpReAllocQPCondition [rkfd_volume]
 2023. 6. 5. Changed the CI service from Travis CI to GitHub Actions. [.github]
 2023. 6. 1. Reflected modification of zeda-makefile-gen to keep roki_fd_export.h. [roki_fd_export]
 2023. 5.20. Reflected new specification of zeda-makefile-gen, and modified src/makefile. [src]

--- a/include/roki_fd/rkfd_volume.h
+++ b/include/roki_fd/rkfd_volume.h
@@ -20,7 +20,7 @@ typedef struct{
   zMat a;
   zVec b, t;
 
-  int fsize, csize;
+  int fsize, csize, nfsize;
   zMat q, nf;
   zVec c, d, f;
   zIndex idx;

--- a/src/rkfd_volume.c
+++ b/src/rkfd_volume.c
@@ -64,10 +64,12 @@ static bool _rkFDSolverPrpReAllocQPCondition(rkFDSolver *s)
 {
   int fnum = 6*rkFDCDRigidNum(s->cd);
   int cnum = rkFDCDRigidNum(s->cd) + _prp(s)->colnum;
+  int nfnum = fnum * cnum;
 
-  if( _prp(s)->fsize * _prp(s)->csize < fnum * cnum ){
+  if( _prp(s)->nfsize < nfnum ){
     zMatFree( _prp(s)->nf );
     _prp(s)->nf = zMatAlloc( cnum, fnum );
+    _prp(s)->nfsize = nfnum;
     if( !_prp(s)->nf )
       return false;
   } else
@@ -973,8 +975,9 @@ bool rkFDSolverUpdateInit_Volume(rkFDSolver *s)
   _prp(s)->b = NULL;
   _prp(s)->t = NULL;
 
-  _prp(s)->fsize = 0;
-  _prp(s)->csize = 0;
+  _prp(s)->fsize  = 0;
+  _prp(s)->csize  = 0;
+  _prp(s)->nfsize = 0;
   _prp(s)->q   = NULL;
   _prp(s)->nf  = NULL;
   _prp(s)->c   = NULL;


### PR DESCRIPTION
#38 の修正になります．

数値計算に使っているワークスペース(行列，ベクトル，インデックス)について，メモリ割り当ての回数を減らすため，前ステップよりサイズが大きくなる場合はreallocし，同じもしくは小さくなる場合は無理やりzMat, zVec内部に持っているsizeを変更するという処理をしていました．
ワークペースの内，摩擦条件の行列(`_prp(s)->nf`)のrealloc判定にバグがあり，範囲外アクセスの可能性があったため修正しました．