### PR TITLE
Renamed project name back from roki_fd to roki-fd.

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,5 @@
+2023. 6.20. Modified arm_box_trq_test and arm_wall_test in example to conform to the current RoKi (thanks to Daishi Kaneta). [example]
+2023. 6.20. Renamed project name back from roki_fd to roki-fd. [all]
 2023. 6.19. Debugged _rkFDSolverPrpReAllocQPCondition [rkfd_volume]
 2023. 6. 5. Changed the CI service from Travis CI to GitHub Actions. [.github]
 2023. 6. 1. Reflected modification of zeda-makefile-gen to keep roki_fd_export.h. [roki_fd_export]

--- a/config.org
+++ b/config.org
@@ -1,5 +1,5 @@
-PREFIX=$(HOME)/usr
-PROJNAME=roki_fd
-VERSION=1.5.2
+PREFIX=${HOME}/usr
+PROJNAME=roki-fd
+VERSION=1.5.3
 
 DEPENDENCY="zeda=1.7.7;zm=1.7.3;zeo=1.13.8;roki=2.2.4"

--- a/example/chain/arm_box_trq_test.c
+++ b/example/chain/arm_box_trq_test.c
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   fp[1] = fopen( "box.zvs", "w" );
 
   rkFDCreate( &fd );
-	rkFDContactInfoScanFile( &fd, "../model/contactinfo.ztk" );
+  rkFDContactInfoScanFile( &fd, "../model/contactinfo.ztk" );
 
   cell[0] = rkFDChainRegFile( &fd, "../model/arm_2DoF_trq.ztk" );
   cell[1] = rkFDChainRegFile( &fd, "../model/box.ztk" );
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
   rkFDUpdateDestroy( &fd );
 
   zVecFreeAO( 2, dis[0], dis[1] );
-  rkFDDestroy(&fd);
+  rkFDDestroy( &fd );
   fclose( fp[0] );
   fclose( fp[1] );
   return 0;

--- a/example/chain/arm_wall_test.c
+++ b/example/chain/arm_wall_test.c
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   fp[1] = fopen( "wall.zvs", "w" );
 
   rkFDCreate( &fd );
-	rkFDContactInfoScanFile( &fd, "../model/contactinfo.ztk" );
+  rkFDContactInfoScanFile( &fd, "../model/contactinfo.ztk" );
 
   cell[0] = rkFDChainRegFile( &fd, "../model/arm_2DoF.ztk" );
   cell[1] = rkFDChainRegFile( &fd, "../model/wall.ztk" );
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
   rkFDUpdateDestroy( &fd );
 
   zVecFreeAO( 2, dis[0], dis[1] );
-  rkFDDestroy(&fd);
+  rkFDDestroy( &fd );
   fclose( fp[0] );
   fclose( fp[1] );
   return 0;

--- a/example/makefile
+++ b/example/makefile
@@ -1,8 +1,8 @@
 include ../../config
 
-INCLUDE=`roki_fd-config -I`
-LIB=`roki_fd-config -L`
-LINK=`roki_fd-config -l`
+INCLUDE=`roki-fd-config -I`
+LIB=`roki-fd-config -L`
+LINK=`roki-fd-config -l`
 
 CC=gcc
 CFLAGS=-ansi -Wall -O3 $(LIB) $(INCLUDE) -funroll-loops -g


### PR DESCRIPTION
@n-wakisaka 
度々済みません。_export.hファイル自動生成の都合でプロジェクト名をroki-fdからroki_fdに変更していたのですが、Satoくんから指摘があって、Debianパッケージは名前に_使えないそうです。というわけで、プロジェクト名が何であれ
 - ヘッダファイルディレクトリ: include/(-を_にしたプロジェクト名)/
 - exportヘッダ: include/(-を_にしたプロジェクト名)/(-を_にしたプロジェクト名)_export.h
 - ライブラリ依存マクロ: __(-を_にした大文字プロジェクト名)_(後修飾)
 - configツール: (_を-にしたプロジェクト名)-config
 - ライブラリファイル: lib(プロジェクト名).so & lib(プロジェクト名)_cpp.so
 - debパッケージ: (_を-にしたプロジェクト名)-dev.deb
となるようにzeda-makefile-gen&zeda-deb-genを修正しました。
ややこしくて済みませんが、マージしてもらえると助かります。