### PR TITLE
Separated config and libinfo.

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,4 @@
+2023. 6.21. Separated config and libinfo. [all]
 2023. 6.20. Modified arm_box_trq_test and arm_wall_test in example to conform to the current RoKi (thanks to Daishi Kaneta). [example]
 2023. 6.20. Renamed project name back from roki_fd to roki-fd. [all]
 2023. 6.19. Debugged _rkFDSolverPrpReAllocQPCondition [rkfd_volume]

--- a/config.org
+++ b/config.org
@@ -1,5 +1,1 @@
 PREFIX=${HOME}/usr
-PROJNAME=roki-fd
-VERSION=1.5.3
-
-DEPENDENCY="zeda=1.7.7;zm=1.7.3;zeo=1.13.8;roki=2.2.4"

--- a/example/makefile
+++ b/example/makefile
@@ -1,5 +1,3 @@
-include ../../config
-
 INCLUDE=`roki-fd-config -I`
 LIB=`roki-fd-config -L`
 LINK=`roki-fd-config -l`

--- a/libinfo
+++ b/libinfo
@@ -1,0 +1,3 @@
+PROJNAME=roki-fd
+VERSION=1.6.0
+DEPENDENCY="zeda=1.8.0;zm=1.8.0;zeo=1.14.0;roki=2.4.0"

--- a/test/makefile
+++ b/test/makefile
@@ -1,5 +1,3 @@
-include ../config
-
 INCLUDE=`roki-fd-config -I`
 LIB=`roki-fd-config -L`
 LINK=`roki-fd-config -l`


### PR DESCRIPTION
@n-wakisaka 
configを分離しました。
libinfo: PROJNAME, VERSION, DEPENDENCY … ライブラリの固有情報（書き換えられては困る情報）
config.org: PREFIX, CONFIG_USE_(いろいろ) … ユーザがインストール環境に合わせて変更する情報
zeda-makefile-genを変えたので、影響範囲はmi-lib全体です。よろしくお願いします。