### PR TITLE
Corrected signedness of integer variables in _rkFDQPSolveASMInitIndex…

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,4 @@
+2023. 6.21. Corrected signedness of integer variables in _rkFDQPSolveASMInitIndex and rkFDQPSolveASM. [rkfd_opt_qp]
 2023. 6.21. Separated config and libinfo. [all]
 2023. 6.20. Modified arm_box_trq_test and arm_wall_test in example to conform to the current RoKi (thanks to Daishi Kaneta). [example]
 2023. 6.20. Renamed project name back from roki_fd to roki-fd. [all]

--- a/libinfo
+++ b/libinfo
@@ -1,3 +1,3 @@
 PROJNAME=roki-fd
-VERSION=1.6.0
+VERSION=1.6.1
 DEPENDENCY="zeda=1.8.0;zm=1.8.0;zeo=1.14.0;roki=2.4.0"

--- a/src/rkfd_opt_qp.c
+++ b/src/rkfd_opt_qp.c
@@ -26,7 +26,7 @@ static double _rkFDQPSolveASMConditionDefault(zMat a, zVec ans, int i, void *uti
 
 static uint _rkFDQPSolveASMInitIndex(zIndex idx, zMat a, zVec b, zVec ans, void *util, double cond(zMat,zVec,int,void*))
 {
-  uint m, i;
+  int m, i;
 
   /* initialize the active set of constraints */
   for( m=0, i=0; i<zVecSizeNC(b); i++ ){
@@ -48,9 +48,9 @@ bool rkFDQPSolveASM(zMat q, zVec c, zMat a, zVec b, zVec ans, zIndex idx, zVec i
   _rkFDQPASMIndexList ilist;
   _rkFDQPASMIndex *idata;
   bool endflag, ret = true;
-  uint tempi;
-  uint n, nm, m;
-  uint i, j, k;
+  int tempi;
+  int n, nm, m;
+  int i, j, k;
 
   /* function settings */
   if( !init ) init = _rkFDQPSolveASMInitDefault;


### PR DESCRIPTION
… and rkFDQPSolveASM.

C++用ライブラリビルドの際に型チェックで弾かれました。
zArrayのサイズをuintでなくintにした影響です（エラー発生時に負値が入り得るようにしました）。
軽微な修正なので問題ないと思いますが、確認よろしくお願いします。
@n-wakisaka 