### PR TITLE
Rename 'zVecFreeAO', 'zMatFreeAO' -> 'zVecFreeAtOnce', 'zMatFreeAtOnce' with zm update

### DIFF
--- a/example/chain/arm_box_test.c
+++ b/example/chain/arm_box_test.c
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
   }
   rkFDUpdateDestroy( &fd );
 
-  zVecFreeAO( 2, dis[0], dis[1] );
+  zVecFreeAtOnce( 2, dis[0], dis[1] );
   rkFDDestroy(&fd);
   fclose( fp[0] );
   fclose( fp[1] );

--- a/example/chain/arm_box_trq_test.c
+++ b/example/chain/arm_box_trq_test.c
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
   }
   rkFDUpdateDestroy( &fd );
 
-  zVecFreeAO( 2, dis[0], dis[1] );
+  zVecFreeAtOnce( 2, dis[0], dis[1] );
   rkFDDestroy( &fd );
   fclose( fp[0] );
   fclose( fp[1] );

--- a/example/chain/arm_wall_test.c
+++ b/example/chain/arm_wall_test.c
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
   }
   rkFDUpdateDestroy( &fd );
 
-  zVecFreeAO( 2, dis[0], dis[1] );
+  zVecFreeAtOnce( 2, dis[0], dis[1] );
   rkFDDestroy( &fd );
   fclose( fp[0] );
   fclose( fp[1] );

--- a/src/rkfd_mlcp.c
+++ b/src/rkfd_mlcp.c
@@ -32,7 +32,7 @@ static bool _rkFDSolverPrpReAlloc(rkFDSolver *s)
 
   if( _prp(s)->size < _prp(s)->colnum ){
     zMatFree( _prp(s)->a );
-    zVecFreeAO( 3, _prp(s)->b, _prp(s)->t, _prp(s)->f );
+    zVecFreeAtOnce( 3, _prp(s)->b, _prp(s)->t, _prp(s)->f );
 
     _prp(s)->size = _prp(s)->colnum;
     _prp(s)->a    = zMatAllocSqr( fnum );
@@ -41,7 +41,7 @@ static bool _rkFDSolverPrpReAlloc(rkFDSolver *s)
     _prp(s)->f    = zVecAlloc( fnum );
     if( !_prp(s)->a || !_prp(s)->b || !_prp(s)->t || !_prp(s)->f ){
       zMatFree( _prp(s)->a );
-      zVecFreeAO( 3, _prp(s)->b, _prp(s)->t, _prp(s)->f );
+      zVecFreeAtOnce( 3, _prp(s)->b, _prp(s)->t, _prp(s)->f );
       return false;
     }
   } else{
@@ -350,7 +350,7 @@ void rkFDSolverUpdatePrevDrivingTrq_MLCP(rkFDSolver *s)
 void rkFDSolverUpdateDestroy_MLCP(rkFDSolver *s)
 {
   zMatFree( _prp(s)->a );
-  zVecFreeAO( 3, _prp(s)->b, _prp(s)->t, _prp(s)->f );
+  zVecFreeAtOnce( 3, _prp(s)->b, _prp(s)->t, _prp(s)->f );
   zFree( _prp(s)->w[0] );
   zFree( _prp(s)->w[1] );
 }

--- a/src/rkfd_opt_qp.c
+++ b/src/rkfd_opt_qp.c
@@ -176,6 +176,6 @@ bool rkFDQPSolveASM(zMat q, zVec c, zMat a, zVec b, zVec ans, zIndex idx, zVec i
     zIndexFree( idata->data.idx );
   zListDestroy( _rkFDQPASMIndex, &ilist );
   zMatFree( qa );
-  zVecFreeAO( 3, xy, cb, d );
+  zVecFreeAtOnce( 3, xy, cb, d );
   return ret;
 }

--- a/src/rkfd_sim.c
+++ b/src/rkfd_sim.c
@@ -58,7 +58,7 @@ void rkFDDestroy(rkFD *fd)
   rkFDCell *lc;
 
   rkFDSolverDestroy( &fd->solver );
-  zVecFreeAO( 3, fd->dis, fd->vel, fd->acc );
+  zVecFreeAtOnce( 3, fd->dis, fd->vel, fd->acc );
   rkFDCDDestroy( &fd->cd );
   rkContactInfoArrayDestroy( &fd->ci );
   while( !zListIsEmpty( &fd->list ) ){
@@ -91,14 +91,14 @@ bool _rkFDAllocJointStatePush(rkFD *fd, rkFDCell *rlc)
       !( fd->acc = zVecAlloc( fd->size+size ) ) ){
     fd->size = 0;
     ZALLOCERROR();
-    zVecFreeAO( 5, pdis, pvel, fd->dis, fd->vel, fd->acc );
+    zVecFreeAtOnce( 5, pdis, pvel, fd->dis, fd->vel, fd->acc );
     return false;
   }
 
   if( fd->size ){
     zRawVecCopy( zVecBufNC(pdis), zVecBufNC(fd->dis), fd->size );
     zRawVecCopy( zVecBufNC(pvel), zVecBufNC(fd->vel), fd->size );
-    zVecFreeAO( 2, pdis, pvel );
+    zVecFreeAtOnce( 2, pdis, pvel );
   }
 
   zListForEach( &fd->list, lc ){
@@ -119,7 +119,7 @@ bool _rkFDAllocJointStatePop(rkFD *fd, rkFDCell *rlc)
   zVecFree( fd->acc );
   if( fd->size - size <= 0 ){
     fd->size = 0;
-    zVecFreeAO( 2, fd->dis, fd->vel );
+    zVecFreeAtOnce( 2, fd->dis, fd->vel );
     fd->dis = NULL;
     fd->vel = NULL;
     fd->acc = NULL;
@@ -132,7 +132,7 @@ bool _rkFDAllocJointStatePop(rkFD *fd, rkFDCell *rlc)
       !( fd->acc = zVecAlloc( fd->size-size ) ) ){
     ZALLOCERROR();
     fd->size = 0;
-    zVecFreeAO( 5, pdis, pvel, fd->dis, fd->vel, fd->acc );
+    zVecFreeAtOnce( 5, pdis, pvel, fd->dis, fd->vel, fd->acc );
     return false;
   }
 
@@ -150,7 +150,7 @@ bool _rkFDAllocJointStatePop(rkFD *fd, rkFDCell *rlc)
   }
   fd->size -= size;
 
-  zVecFreeAO( 2, pdis, pvel );
+  zVecFreeAtOnce( 2, pdis, pvel );
   return true;
 }
 

--- a/src/rkfd_util.c
+++ b/src/rkfd_util.c
@@ -203,7 +203,7 @@ bool rkFDCrateSinCosTable(zVec table[2], int num, double offset){
 	table[0] = zVecAlloc( num );
 	table[1] = zVecAlloc( num );
   if( table[0] == NULL || table[1] == NULL ){
-    zVecFreeAO( 2, table[0], table[1] );
+    zVecFreeAtOnce( 2, table[0], table[1] );
     return false;
   }
 	dth = zDeg2Rad( 360 ) / num;

--- a/src/rkfd_vert.c
+++ b/src/rkfd_vert.c
@@ -35,8 +35,8 @@ static bool _rkFDSolverPrpReAlloc(rkFDSolver *s)
   int cnum = rkFDPrpPyramid(s->fdprp) * _prp(s)->colnum;
 
   if( _prp(s)->qp_size < _prp(s)->colnum ){
-    zMatFreeAO( 3, _prp(s)->a, _prp(s)->q, _prp(s)->nf );
-    zVecFreeAO( 5, _prp(s)->b, _prp(s)->t, _prp(s)->c, _prp(s)->d, _prp(s)->f );
+    zMatFreeAtOnce( 3, _prp(s)->a, _prp(s)->q, _prp(s)->nf );
+    zVecFreeAtOnce( 5, _prp(s)->b, _prp(s)->t, _prp(s)->c, _prp(s)->d, _prp(s)->f );
     zIndexFree( _prp(s)->idx );
 
     _prp(s)->qp_size = _prp(s)->colnum;
@@ -50,8 +50,8 @@ static bool _rkFDSolverPrpReAlloc(rkFDSolver *s)
     _prp(s)->d       = zVecAlloc( cnum );
     _prp(s)->idx     = zIndexCreate( cnum );
     if( !_prp(s)->a || !_prp(s)->q || !_prp(s)->nf || !_prp(s)->b || !_prp(s)->t || !_prp(s)->c || !_prp(s)->d || !_prp(s)->f || !_prp(s)->idx ){
-      zMatFreeAO( 3, _prp(s)->a, _prp(s)->q, _prp(s)->nf );
-      zVecFreeAO( 5, _prp(s)->b, _prp(s)->t, _prp(s)->c, _prp(s)->d, _prp(s)->f );
+      zMatFreeAtOnce( 3, _prp(s)->a, _prp(s)->q, _prp(s)->nf );
+      zVecFreeAtOnce( 5, _prp(s)->b, _prp(s)->t, _prp(s)->c, _prp(s)->d, _prp(s)->f );
       zIndexFree( _prp(s)->idx );
       return false;
     }
@@ -393,8 +393,8 @@ void rkFDSolverUpdatePrevDrivingTrq_Vert(rkFDSolver *s)
 }
 
 void rkFDSolverUpdateDestroy_Vert(rkFDSolver *s){
-  zMatFreeAO( 3, _prp(s)->a, _prp(s)->q, _prp(s)->nf );
-  zVecFreeAO( 7, _prp(s)->b, _prp(s)->t, _prp(s)->c, _prp(s)->d, _prp(s)->f, _prp(s)->sc_table[0], _prp(s)->sc_table[1] );
+  zMatFreeAtOnce( 3, _prp(s)->a, _prp(s)->q, _prp(s)->nf );
+  zVecFreeAtOnce( 7, _prp(s)->b, _prp(s)->t, _prp(s)->c, _prp(s)->d, _prp(s)->f, _prp(s)->sc_table[0], _prp(s)->sc_table[1] );
   zFree( _prp(s)->w[0] );
   zFree( _prp(s)->w[1] );
   zIndexFree( _prp(s)->idx );

--- a/src/rkfd_volume.c
+++ b/src/rkfd_volume.c
@@ -34,8 +34,8 @@ static bool _rkFDSolverPrpReAllocQP(rkFDSolver *s)
   int fnum = 6*rkFDCDRigidNum(s->cd);
 
   if( _prp(s)->fsize < fnum ){
-    zMatFreeAO( 2, _prp(s)->a, _prp(s)->q );
-    zVecFreeAO( 4, _prp(s)->b, _prp(s)->t, _prp(s)->c, _prp(s)->f );
+    zMatFreeAtOnce( 2, _prp(s)->a, _prp(s)->q );
+    zVecFreeAtOnce( 4, _prp(s)->b, _prp(s)->t, _prp(s)->c, _prp(s)->f );
 
     _prp(s)->fsize = fnum;
     _prp(s)->a = zMatAllocSqr( fnum );
@@ -45,8 +45,8 @@ static bool _rkFDSolverPrpReAllocQP(rkFDSolver *s)
     _prp(s)->c = zVecAlloc( fnum );
     _prp(s)->f = zVecAlloc( fnum );
     if( !_prp(s)->a || !_prp(s)->q || !_prp(s)->b || !_prp(s)->t || !_prp(s)->c || !_prp(s)->f ){
-      zMatFreeAO( 2, _prp(s)->a, _prp(s)->q );
-      zVecFreeAO( 4, _prp(s)->b, _prp(s)->t, _prp(s)->c, _prp(s)->f );
+      zMatFreeAtOnce( 2, _prp(s)->a, _prp(s)->q );
+      zVecFreeAtOnce( 4, _prp(s)->b, _prp(s)->t, _prp(s)->c, _prp(s)->f );
       return false;
     }
   } else {
@@ -103,14 +103,14 @@ static bool _rkFDSolverPrpReAllocModification(rkFDSolver *s)
 
   if( _prp(s)->pvsize < pvnum ){
     zMatFree( _prp(s)->ma );
-    zVecFreeAO( 2, _prp(s)->mc, _prp(s)->mf );
+    zVecFreeAtOnce( 2, _prp(s)->mc, _prp(s)->mf );
 
     _prp(s)->ma = zMatAlloc( 6, rkFDPrpPyramid(s->fdprp) * pvnum );
     _prp(s)->mc = zVecAlloc( pvnum );
     _prp(s)->mf = zVecAlloc( rkFDPrpPyramid(s->fdprp) * pvnum );
     if( !_prp(s)->ma || !_prp(s)->mc || !_prp(s)->mf ){
       zMatFree( _prp(s)->ma );
-      zVecFreeAO( 2, _prp(s)->mc, _prp(s)->mf );
+      zVecFreeAtOnce( 2, _prp(s)->mc, _prp(s)->mf );
       return false;
     }
   }
@@ -1025,14 +1025,14 @@ void rkFDSolverUpdatePrevDrivingTrq_Volume(rkFDSolver *s)
 
 void rkFDSolverUpdateDestroy_Volume(rkFDSolver *s)
 {
-  zMatFreeAO( 3, _prp(s)->a, _prp(s)->q, _prp(s)->nf );
-  zVecFreeAO( 7, _prp(s)->b, _prp(s)->t, _prp(s)->c, _prp(s)->d, _prp(s)->f, _prp(s)->sc_table[0], _prp(s)->sc_table[1] );
+  zMatFreeAtOnce( 3, _prp(s)->a, _prp(s)->q, _prp(s)->nf );
+  zVecFreeAtOnce( 7, _prp(s)->b, _prp(s)->t, _prp(s)->c, _prp(s)->d, _prp(s)->f, _prp(s)->sc_table[0], _prp(s)->sc_table[1] );
   zFree( _prp(s)->w[0] );
   zFree( _prp(s)->w[1] );
   zIndexFree( _prp(s)->idx );
 
   zMatFree( _prp(s)->ma );
-  zVecFreeAO( 3, _prp(s)->mb, _prp(s)->mc, _prp(s)->mf );
+  zVecFreeAtOnce( 3, _prp(s)->mb, _prp(s)->mc, _prp(s)->mf );
 }
 
 RKFD_SOLVER_DEFAULT_GENERATOR( Volume )


### PR DESCRIPTION
As the title suggests, some errors occurred, so it was fixed.  