### PR TITLE
関数名変更への対応

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,4 @@
+2025. 1.22. Reflected renaming of zEqual. [rkfd_opt_qp]
 2024.11.12. Modified .gitignore. [all]
 2024.10.29. Reflected new tags of Zeo and RoKi for ZTK. [example]
 2024. 8. 6. Modified makefile in example to enable batch compilation of all examples in the same directory. [example]

--- a/libinfo
+++ b/libinfo
@@ -1,3 +1,3 @@
 PROJNAME=roki-fd
-VERSION=1.7.0
-DEPENDENCY="zeda=1.9.13;zm=1.9.2;zeo=1.16.0;roki=2.9.0"
+VERSION=1.7.1
+DEPENDENCY="zeda=1.10.2;zm=1.10.1;zeo=1.17.19;roki=2.10.11"

--- a/src/rkfd_opt_qp.c
+++ b/src/rkfd_opt_qp.c
@@ -30,7 +30,7 @@ static uint _rkFDQPSolveASMInitIndex(zIndex idx, zMat a, zVec b, zVec ans, void 
 
   /* initialize the active set of constraints */
   for( m=0, i=0; i<zVecSizeNC(b); i++ ){
-    if( zIsEqual( cond( a, ans, i, util ), zVecElemNC(b,i), zTOL ) ){
+    if( zEqual( cond( a, ans, i, util ), zVecElemNC(b,i), zTOL ) ){
       zIndexElemNC(idx,i) = 1;
       m++;
     } else
@@ -107,7 +107,7 @@ bool rkFDQPSolveASM(zMat q, zVec c, zMat a, zVec b, zVec ans, zIndex idx, zVec i
     zLESolveMP( qa, cb, NULL, NULL, xy );
 
     for( i=0; i<n; i++ )
-      if( !zIsEqual( zVecElemNC(xy,i), zVecElemNC(ans,i), zTOL ) ) goto STEP2;
+      if( !zEqual( zVecElemNC(xy,i), zVecElemNC(ans,i), zTOL ) ) goto STEP2;
     for( i=0; i<n; i++ )
       zVecElemNC(ans,i) = zVecElemNC(xy,i);
     for( i=0; i<m; i++ )
@@ -145,7 +145,7 @@ bool rkFDQPSolveASM(zMat q, zVec c, zMat a, zVec b, zVec ans, zIndex idx, zVec i
     for( i=0; i<n; i++ )
       zVecElemNC(ans,i) += tempd * zVecElemNC(d,i);
     for( i=0; i<zVecSizeNC(b); i++ )
-      if( zIndexElemNC(idx,i) == 0 && zIsEqual( cond( a, ans, i, util ), zVecElemNC(b,i), zTOL ) ){
+      if( zIndexElemNC(idx,i) == 0 && zEqual( cond( a, ans, i, util ), zVecElemNC(b,i), zTOL ) ){
         zIndexElemNC(idx,i) = 1;
         m++;
       }


### PR DESCRIPTION
@n-wakisaka 
ZEDAの関数 `zIsEqual()`を`zEqual()`に改名しました。比較対象は二つなので、動詞が "is" なのは変だと思ったため。
ZM, DZco, Zeo, RoKiも併せて更新しています。
RoKi-FDへの影響は軽微でした。rkfd_opt_qp.cを何か所か直しただけです。
問題なければ、他ライブラリ群の更新とマージをお願いします。

＃これの他にライセンスについてのPRも出しています。そちらをマージしてもらえるなら、この変更は反映されているのでrejectして下さい。