### PR TITLE
Fix build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,17 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3  
+      - uses: actions/checkout@v4
+      - name: install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libxml2-dev \
+            liblzf-dev
+
       - name: setup env
         run: |
           echo "PREFIX=${HOME}/usr/" >> $GITHUB_ENV


### PR DESCRIPTION
#57 の修正になります。
https://github.com/mi-lib/mi-lib-starter を使おうと思ったのですが、roki-fdが依存していないパッケージも含まれてしまうのでこれまで通りの方法で必要なパッケージを入れる形にしました。