### PR TITLE
Removed register qualifiers from example codes.

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,4 @@
+2025.05.11. Removed register qualifiers from example codes. [example]
 2025.04.29. Modified makefile to conform to new specification of zeda-makefile-gen. [all]
 2025.04.29. Modified makefile in example. [example]
 2025.01.22. Changed the license from LGPL-3 to MIT license. [all]

--- a/example/chain/arm_box_test.c
+++ b/example/chain/arm_box_test.c
@@ -9,7 +9,7 @@
 
 void control(rkFDCell *cell)
 {
-  register int i;
+  int i;
   double dis, vel, e;
   rkJoint *joint;
 

--- a/example/chain/arm_box_trq_test.c
+++ b/example/chain/arm_box_trq_test.c
@@ -9,7 +9,7 @@
 
 void control(rkFDCell *cell)
 {
-  register int i;
+  int i;
   double dis, vel, e;
   rkJoint *joint;
 

--- a/example/chain/arm_wall_test.c
+++ b/example/chain/arm_wall_test.c
@@ -9,7 +9,7 @@
 
 void control(rkFDCell *cell)
 {
-  register int i;
+  int i;
   double dis, vel, e;
   rkJoint *joint;
 

--- a/libinfo
+++ b/libinfo
@@ -1,3 +1,3 @@
 PROJNAME=roki-fd
-VERSION=1.7.2
+VERSION=1.7.3
 DEPENDENCY="zeda=1.11.0;zm=1.12.12;zeo=1.18.2;roki=2.11.3"


### PR DESCRIPTION
C++17以降register修飾子は廃止されたので、exampleコードから削除しました。
ライブラリ本体に変更はありません。
確認お願いします。