### PR TITLE
Modified _rkFDSolverConstraintAddQ to reflect renaming of _zVec3DOuterProdToMat3D and _zVec3DTripleProdToMat3D.

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,4 @@
+2025.11.16. Modified _rkFDSolverConstraintAddQ to reflect renaming of _zVec3DOuterProdToMat3D and _zVec3DTripleProdToMat3D. [rkfd_volume]
 2025.10.17. Reflected renaming of member f to wrench of rkCDPairDat. [rkfd_volume]
 2025.05.11. Removed register qualifiers from example codes. [example]
 2025.04.29. Modified makefile to conform to new specification of zeda-makefile-gen. [all]

--- a/libinfo
+++ b/libinfo
@@ -1,3 +1,3 @@
 PROJNAME=roki-fd
-VERSION=1.7.4
-DEPENDENCY="zeda=1.11.8;zm=1.12.12;zeo=1.19.9;roki=2.12.8"
+VERSION=1.7.5
+DEPENDENCY="zeda=1.11.22;zm=1.12.20;zeo=1.19.15;roki=2.12.12"

--- a/src/rkfd_volume.c
+++ b/src/rkfd_volume.c
@@ -285,10 +285,10 @@ static void _rkFDSolverConstraintAddQ(zVec3D p[], zVec3D pm[], double s, zMat6D 
   _rkFDSolverConstraintAvePoint( p, s, &pc );
   zMat3DMul( ZMAT3DIDENT, s, &tmpm );
   zMat3DAddDRC( &q->e[0][0], &tmpm );
-  _zVec3DOuterProd2Mat3D( &pc, &tmpm );
+  _zVec3DOuterProdToMat3D( &pc, &tmpm );
   zMat3DAddDRC( &q->e[1][0], &tmpm );
   zMat3DSubDRC( &q->e[0][1], &tmpm );
-  for( i=0; i<3; i++ ) _zVec3DTripleProd2Mat3D( &pm[i], &pm[i], &mm[i] );
+  for( i=0; i<3; i++ ) _zVec3DTripleProdToMat3D( &pm[i], &pm[i], &mm[i] );
   _rkFDSolverConstraintAveMat( mm, s, &tmpm );
   zMat3DSubDRC( &q->e[1][1], &tmpm );
 }


### PR DESCRIPTION
タイトルの通り、Zeoの関数幾つか名前を変えました。それへの対応です。機能は変わっていません。
問題なければマージお願いします。 @n-wakisaka 