### PR TITLE
Replace xargs -i with -I

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,4 @@
+2025.12.16. Replaced xargs -i option with -I option. [example]
 2025.11.16. Modified _rkFDSolverConstraintAddQ to reflect renaming of _zVec3DOuterProdToMat3D and _zVec3DTripleProdToMat3D. [rkfd_volume]
 2025.10.17. Reflected renaming of member f to wrench of rkCDPairDat. [rkfd_volume]
 2025.05.11. Removed register qualifiers from example codes. [example]

--- a/example/makefile
+++ b/example/makefile
@@ -2,7 +2,7 @@ INCLUDE=`roki-fd-config -I`
 LIB=`roki-fd-config -L`
 LINK=`roki-fd-config -l`
 
-TARGET=$(shell ls *.c | xargs -i basename {} .c | tr -s "\n" " ")
+TARGET=$(shell ls *.c | xargs -I{} basename {} .c | tr -s "\n" " ")
 
 CC=gcc
 CFLAGS=-ansi -Wall -O3 $(LIB) $(INCLUDE) -funroll-loops -g

--- a/libinfo
+++ b/libinfo
@@ -1,3 +1,3 @@
 PROJNAME=roki-fd
-VERSION=1.7.5
+VERSION=1.7.6
 DEPENDENCY="zeda=1.11.22;zm=1.12.20;zeo=1.19.15;roki=2.12.12"


### PR DESCRIPTION
xargsの-iオプションが非推奨になっていたので-Iに修正しました。特にmacでビルドする場合`-i`オプションがなくエラーになります。

@zhidao 問題なさそうでしたら、その他のmilibライブラリにも反映できればと思うのですがいかがでしょうか。
必要なら同様のPR作成します。