### PR TITLE
ZEDA&ZM仕様変更に伴う修正

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,6 @@
+2026. 1.23. Modified rkFDODECatDefault, rkFDODESubDefault, rkFDFK, and rkFDUpdateRate to use zVecAssignArray. [rkfd_sim]
+2026. 1.23. Modified rkFDUpdateInit to reflect renaming of zODE2Init to zODE2Create. [rkfd_sim]
+2026. 1.22. Modified _rkFDSolverQPCreate to reflect new specification of zMat. [rkfd_volume]
 2025.12.16. Replaced xargs -i option with -I option. [example]
 2025.11.16. Modified _rkFDSolverConstraintAddQ to reflect renaming of _zVec3DOuterProdToMat3D and _zVec3DTripleProdToMat3D. [rkfd_volume]
 2025.10.17. Reflected renaming of member f to wrench of rkCDPairDat. [rkfd_volume]

--- a/libinfo
+++ b/libinfo
@@ -1,3 +1,3 @@
 PROJNAME=roki-fd
-VERSION=1.7.6
-DEPENDENCY="zeda=1.11.22;zm=1.12.20;zeo=1.19.15;roki=2.12.12"
+VERSION=1.7.7
+DEPENDENCY="zeda=1.11.25;zm=1.14.0;zeo=1.19.15;roki=2.12.12"

--- a/src/rkfd_sim.c
+++ b/src/rkfd_sim.c
@@ -307,13 +307,13 @@ zVec rkFDODECatDefault(zVec x, double k, zVec v, zVec xnew, void *util)
 {
   rkFDCell *lc;
   zVecStruct lv, lxn;
+  int jointsize;
 
   zVecCopyNC( x, xnew );
   zListForEach( &((rkFD *)util)->list, lc ){
-    lv.size  = rkChainJointSize( rkFDCellChain(lc) );
-    lxn.size = rkChainJointSize( rkFDCellChain(lc) );
-    lv.buf   = &zVecElemNC(v,   lc->data._offset);
-    lxn.buf  = &zVecElemNC(xnew,lc->data._offset);
+    jointsize = rkChainJointSize( rkFDCellChain(lc) );
+    zVecAssignArray( &lv,  jointsize, &zVecElemNC(v,   lc->data._offset) );
+    zVecAssignArray( &lxn, jointsize, &zVecElemNC(xnew,lc->data._offset) );
     rkChainCatJointDisAll( rkFDCellChain(lc), &lxn, k, &lv );
   }
   return xnew;
@@ -323,13 +323,13 @@ zVec rkFDODESubDefault(zVec x1, zVec x2, zVec dx, void *util)
 {
   rkFDCell *lc;
   zVecStruct lx2, ldx;
+  int jointsize;
 
   zVecCopyNC( x1, dx );
   zListForEach( &((rkFD *)util)->list, lc ){
-    lx2.size = rkChainJointSize( rkFDCellChain(lc) );
-    ldx.size = rkChainJointSize( rkFDCellChain(lc) );
-    lx2.buf  = &zVecElemNC(x2,lc->data._offset);
-    ldx.buf  = &zVecElemNC(dx,lc->data._offset);
+    jointsize = rkChainJointSize( rkFDCellChain(lc) );
+    zVecAssignArray( &lx2, jointsize, &zVecElemNC(x2,lc->data._offset) );
+    zVecAssignArray( &ldx, jointsize, &zVecElemNC(dx,lc->data._offset) );
     rkChainSubJointDisAll( rkFDCellChain(lc), &ldx, &lx2 );
   }
   return dx;
@@ -347,8 +347,7 @@ void rkFDFK(rkFD *fd, zVec dis)
   zVecStruct ldis;
 
   zListForEach( &fd->list, lc ){
-    ldis.size = rkChainJointSize( rkFDCellChain(lc) );
-    ldis.buf  = &zVecElemNC(dis,lc->data._offset);
+    zVecAssignArray( &ldis, rkChainJointSize( rkFDCellChain(lc) ), &zVecElemNC(dis,lc->data._offset) );
     rkChainFK( rkFDCellChain(lc), &ldis );
   }
 }
@@ -357,11 +356,12 @@ void rkFDUpdateRate(rkFD *fd, zVec vel, zVec acc)
 {
   rkFDCell *lc;
   zVecStruct lvel, lacc;
+  int jointsize;
 
   zListForEach( &fd->list, lc ){
-    lvel.size = lacc.size = rkChainJointSize( rkFDCellChain(lc) );
-    lvel.buf  = &zVecElemNC(vel,lc->data._offset);
-    lacc.buf  = &zVecElemNC(acc,lc->data._offset);
+    jointsize = rkChainJointSize( rkFDCellChain(lc) );
+    zVecAssignArray( &lvel, jointsize, &zVecElemNC(vel,lc->data._offset) );
+    zVecAssignArray( &lacc, jointsize, &zVecElemNC(acc,lc->data._offset) );
     rkChainSetJointRateAll( rkFDCellChain(lc), &lvel, &lacc );
     rkChainUpdateRateGrav( rkFDCellChain(lc) );
   }
@@ -554,7 +554,7 @@ void rkFDUpdateInit(rkFD *fd)
   rkFDCDUpdateInit( &fd->cd );
   _rkFDUpdateInitSolver( fd );
   _rkFDUpdateRef( fd );
-  zODE2Init( &fd->ode, zVecSize( fd->dis ), fd->ode_step, _rkFDUpdate );
+  zODE2Create( &fd->ode, zVecSize( fd->dis ), fd->ode_step, _rkFDUpdate );
 }
 
 rkFD *rkFDUpdate(rkFD *fd)

--- a/src/rkfd_volume.c
+++ b/src/rkfd_volume.c
@@ -509,7 +509,7 @@ static void _rkFDSolverQPCreate(rkFDSolver *s)
     /* q */
     for( i=0; i<6; i++ )
       for( j=0; j<6; j++ )
-        zRawMatCatDyad( zMatBuf(_prp(s)->q), _zMat6DElem(&qv,i,j), zMatRowBuf(_prp(s)->a,offset+i), zMatColSizeNC(_prp(s)->a), zMatRowBuf(_prp(s)->a,offset+j), zMatColSizeNC(_prp(s)->a) );
+        zRawMatCatDyad( zMatBufNC(_prp(s)->q), zMatColCapacity(_prp(s)->q), _zMat6DElem(&qv,i,j), zMatRowBufNC(_prp(s)->a,offset+i), zMatColSizeNC(_prp(s)->a), zMatRowBufNC(_prp(s)->a,offset+j), zMatColSizeNC(_prp(s)->a) );
     /* c */
     zMulMat6DVec6D( &qv, (zVec6D *)&zVecElemNC(_prp(s)->b,offset), &tmpv );
     zVec6DAddDRC( &cv, &tmpv );


### PR DESCRIPTION
@n-wakisaka 
ZEDAの `zArray` `zArray2` の仕様を変更しました。 `size` の他に `capacity` メンバを追加し、配列の最大サイズを保存するようにしました。また、2次元配列のコラムサイズを `colsize` ではなく `colcapacity` とする（ (i,j)成分は i*cosize+j でなく i*colcapacity+j でアクセスするようにする）ことで、コラムサイズを変更しても元のデータの並びを変えずそのまま使えるようにしました。これに伴って、 `zIndex` `zVec` `zMat` 関連の処理がいろいろ変わっています。
RoKi-FDにも修正が必要になったので、直しました。

ただし、この修正が直接の原因かどうかは分かりませんが、デグレが発生しているようです。example/chain/boxdrop_testを走らせたら、途中からNANが出ます。済みませんが確認してもらえませんか？
できればこの機会に test/ 以下を整備してもらえると助かります。