### PR TITLE
ZEDA zListClassとzArrayClassの改名による修正

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,4 @@
+2026.04.24. Applied renaming of zArrayClass to ZEDA_DEF_ARRAY_CLASS. [rkfd_cd, rkfd_chain]
 2026.04.22. Applied renaming of zListClass to ZEDA_DEF_LIST_CLASS. [rkfd_sim, rkfd_opt_qp]
 2026.04.19. Modified argument types of __rk_fd_plane_cmp as to conform to new specification of ZEDA_DEF_LIST_QUICKSORT. [rkfd_volume]
 2026.01.23. Modified rkFDODECatDefault, rkFDODESubDefault, rkFDFK, and rkFDUpdateRate to use zVecAssignArray. [rkfd_sim]

--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,4 @@
+2026.04.22. Applied renaming of zListClass to ZEDA_DEF_LIST_CLASS. [rkfd_sim, rkfd_opt_qp]
 2026.04.19. Modified argument types of __rk_fd_plane_cmp as to conform to new specification of ZEDA_DEF_LIST_QUICKSORT. [rkfd_volume]
 2026.01.23. Modified rkFDODECatDefault, rkFDODESubDefault, rkFDFK, and rkFDUpdateRate to use zVecAssignArray. [rkfd_sim]
 2026.01.23. Modified rkFDUpdateInit to reflect renaming of zODE2Init to zODE2Create. [rkfd_sim]

--- a/include/roki_fd/rkfd_cd.h
+++ b/include/roki_fd/rkfd_cd.h
@@ -14,7 +14,7 @@
 
 __BEGIN_DECLS
 
-zArrayClass( rkCDPairArray, rkCDPairDat* );
+ZEDA_DEF_ARRAY_CLASS( rkCDPairArray, rkCDPairDat* );
 /* typedef struct{ */
 /*   rkCDPairDat* pd; */
 /*   void *prp; */

--- a/include/roki_fd/rkfd_chain.h
+++ b/include/roki_fd/rkfd_chain.h
@@ -20,7 +20,7 @@ typedef struct{
 #define rkFDChainBase(c)    ( (rkChain*)(c) )
 #define rkFDChainDerived(c) ( (rkFDChain*)(c) )
 
-zArrayClass( rkFDChainArray, rkFDChain* );
+ZEDA_DEF_ARRAY_CLASS( rkFDChainArray, rkFDChain* );
 #define rkFDChainArrayNum(c)    zArrayNum(c)
 #define rkFDChainArrayElem(c,i) *zArrayElem(c,i)
 

--- a/include/roki_fd/rkfd_sim.h
+++ b/include/roki_fd/rkfd_sim.h
@@ -29,7 +29,7 @@ typedef struct{
   zVecStruct _acc; /* acceleration */
 } rkFDCellDat;
 
-zListClass( rkFDCellList, rkFDCell, rkFDCellDat );
+ZEDA_DEF_LIST_CLASS( rkFDCellList, rkFDCell, rkFDCellDat );
 
 #define rkFDCellDatChain(d) rkFDChainBase(&(d)->fc)
 #define rkFDCellChain(c)    rkFDCellDatChain(&(c)->data)

--- a/libinfo
+++ b/libinfo
@@ -1,3 +1,3 @@
 PROJNAME=roki-fd
-VERSION=1.7.8
-DEPENDENCY="zeda=1.12.0;zm=1.14.0;zeo=1.20.7;roki=2.13.12"
+VERSION=1.7.9
+DEPENDENCY="zeda=1.12.1;zm=1.14.5;zeo=1.20.8;roki=2.13.13"

--- a/src/rkfd_opt_qp.c
+++ b/src/rkfd_opt_qp.c
@@ -12,7 +12,7 @@ typedef struct{ /* list of active set indices */
   zIndex idx;
   double min;
 } _rkFDQPASMIndexData;
-zListClass( _rkFDQPASMIndexList, _rkFDQPASMIndex, _rkFDQPASMIndexData );
+ZEDA_DEF_LIST_CLASS( _rkFDQPASMIndexList, _rkFDQPASMIndex, _rkFDQPASMIndexData );
 
 static zVec _rkFDQPSolveASMInitDefault(zMat a, zVec b, zVec ans, void *util)
 {


### PR DESCRIPTION
@n-wakisaka 
https://github.com/mi-lib/zeda/issues/13#issue-4308459716 で予告していましたが、
`zListClass` を `ZEDA_DEF_LIST_CLASS` に、 `zArrayClass` を `ZEDA_DEF_ARRAY_CLASS` にそれぞれ改名したので、ほぼ全ての他のライブラリに影響が及びました。RoKi-FDについての修正がこのPRになります。確認お願いします。